### PR TITLE
docker-composeでコンテナを管理する

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.7'
+
+services:
+  api:
+    build: ./api
+    container_name: docker-sample_api
+    stdin_open: true
+    tty: true
+    volumes:
+      - ./api:/api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,8 @@ services:
     tty: true
     volumes:
       - ./api:/api
+      - bundle:/usr/local/bundle
+
+volumes:
+  bundle:
+    name: docker-sample_api_bundle


### PR DESCRIPTION
# 目的
docker-composeでコンテナを管理する

以下のPRで作成したRailsアプリケーションのコンテナが管理対象
https://github.com/snowfield702/rails-sample/pull/1

# やったこと
- Create docker-compose.yml
  - version 3.7
  - api/Dockerfileを利用
  - コンテナの標準入出力をホストと繋げる
  - ホストとコンテナでapi配下を同期する
  - gemのインストール先にdocker volumeを割り当てる