### PR TITLE
DBに接続する環境を整える

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,29 @@ services:
   api:
     build: ./api
     container_name: docker-sample_api
+    depends_on:
+      - db
+    environment:
+      DEVELOPMENT_DB_HOST: db
+      DEVELOPMENT_DB_PASSWORD: password
+      TEST_DB_HOST: db
+      TEST_DB_PASSWORD: password
     stdin_open: true
     tty: true
     volumes:
       - ./api:/api
       - bundle:/usr/local/bundle
+  db:
+    command: --sql_mode="NO_ENGINE_SUBSTITUTION"
+    container_name: docker-sample_db
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+    image: mysql:5.7
+    volumes:
+      - mysql:/var/lib/mysql
 
 volumes:
   bundle:
     name: docker-sample_api_bundle
+  mysql:
+    name: docker-sample_db_mysql


### PR DESCRIPTION
# 目的
DBに接続する環境を整える

## やったこと
- dbコンテナを追加
  - mysql 5.7
  - --sql_mode="NO_ENGINE_SUBSTITUTION" を指定
  - docker volumeを割り当て
- apiコンテナにDB接続情報に関する環境変数追加
  - https://github.com/snowfield702/rails-sample/pull/2
