### PR TITLE
Docker立ち上げ時にrails serverを立ち上げる

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.7'
 services:
   api:
     build: ./api
+    command: bin/rails s puma
     container_name: docker-sample_api
     depends_on:
       - db
@@ -11,6 +12,8 @@ services:
       DEVELOPMENT_DB_PASSWORD: password
       TEST_DB_HOST: db
       TEST_DB_PASSWORD: password
+    ports:
+      - '3000:3000'
     stdin_open: true
     tty: true
     volumes:


### PR DESCRIPTION
# 目的
Docker環境を立ち上げた時に rails server が立ち上がるようにする

# やったこと
- rails server は puma を利用
- ローカル環境の3000ポートを割り当て
