### PR TITLE
 git submoduleの利用を廃止

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Ignore all tempfiles.
 /tmp/*
 !/tmp/.keep
+api

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "api"]
-	path = api
-	url = https://github.com/snowfield702/rails-sample.git

--- a/bin/docker
+++ b/bin/docker
@@ -66,6 +66,9 @@ function init() {
     destroy
   fi
   echo -e $'\n\e[32mInitialize docker images, network, and volumes\e[m'
+  if [ ! -e api ]; then
+     git clone git@github.com:snowfield702/rails-sample.git api
+  fi
   docker-compose run --rm api bundle install -j4 --system --clean
   init_db
   touch tmp/docker-init.lock

--- a/bin/docker
+++ b/bin/docker
@@ -66,7 +66,6 @@ function init() {
     destroy
   fi
   echo -e $'\n\e[32mInitialize docker images, network, and volumes\e[m'
-  git submodule update -i
   docker-compose run --rm api bundle install -j4 --system --clean
   init_db
   touch tmp/docker-init.lock


### PR DESCRIPTION
# 目的
git submoduleの利用を廃止して、環境構築時に必要なリポジトリをgit cloneで取得するようにする

submoduleの更新が多いと、そのたびにこのリポジトリもコミットしていく必要がある。
複数人で開発すると盛大にコンフリクトが発生することが考えられるため廃止することにした

# やったこと
- submodule を廃止
  - rm .gitmodules
  - rm -rf api
  - git rm --cached api
- api を .gitignoreに追加
- 環境構築時に必要なリポジトリをgit cloneで取得するようにする