### PR TITLE
springを使えるようにする

### DIFF
--- a/bin/docker
+++ b/bin/docker
@@ -16,8 +16,8 @@ Commands:
   clean       Remove all containers and images
   exec        Run command in choosed container
   init        Initialize docker images, network, and volumes
-  rails       Run rails in api container
-  rake        Run rake in api container
+  rails       Run rails in spring container
+  rake        Run rake in spring container
   run         Start choosed container and run command
   stats       Display a live stream of containers resource usage statistics
   stop        Stop containers
@@ -75,11 +75,11 @@ function init() {
 }
 
 function rails() {
-  docker-compose exec api bin/rails $@
+  docker-compose exec spring bin/rails $@
 }
 
 function rake() {
-  docker-compose exec api bin/rake $@
+  docker-compose exec spring bin/rake $@
 }
 
 function run() {
@@ -108,6 +108,10 @@ function up() {
 }
 
 function rm_pids() {
+  if [ -e tmp/spring ]; then
+     rm -rf tmp/spring
+  fi
+
   if [ -e tmp/pids/server.pid ]; then
      rm tmp/pids/server.pid
   fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,8 @@
 version: '3.7'
 
-services:
-  api:
+x-custom:
+  rails: &rails
     build: ./api
-    command: bin/rails s puma
-    container_name: docker-sample_api
     depends_on:
       - db
     environment:
@@ -12,13 +10,19 @@ services:
       DEVELOPMENT_DB_PASSWORD: password
       TEST_DB_HOST: db
       TEST_DB_PASSWORD: password
-    ports:
-      - '3000:3000'
     stdin_open: true
     tty: true
     volumes:
       - ./api:/api
       - bundle:/usr/local/bundle
+
+services:
+  api:
+    <<: *rails
+    command: bin/rails s puma
+    container_name: docker-sample_api
+    ports:
+      - '3000:3000'
   db:
     command: --sql_mode="NO_ENGINE_SUBSTITUTION"
     container_name: docker-sample_db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ x-custom:
     environment:
       DEVELOPMENT_DB_HOST: db
       DEVELOPMENT_DB_PASSWORD: password
+      SPRING_TMP_PATH: /tmp/spring
       TEST_DB_HOST: db
       TEST_DB_PASSWORD: password
     stdin_open: true
@@ -15,6 +16,7 @@ x-custom:
     volumes:
       - ./api:/api
       - bundle:/usr/local/bundle
+      - spring:/tmp/spring
 
 services:
   api:
@@ -23,6 +25,10 @@ services:
     container_name: docker-sample_api
     ports:
       - '3000:3000'
+  spring:
+    <<: *rails
+    container_name: docker-sample_spring
+    command: bin/spring server
   db:
     command: --sql_mode="NO_ENGINE_SUBSTITUTION"
     container_name: docker-sample_db
@@ -37,3 +43,5 @@ volumes:
     name: docker-sample_api_bundle
   mysql:
     name: docker-sample_db_mysql
+  spring:
+    name: docker-sample_spring_socket


### PR DESCRIPTION
# 目的
springを使えるようにする

`bin/docker exec rails c`などを使ってapiコンテナでspringを起動しても、コンソールを終了するとspring serverも一緒に終了してしまう。
これはプロセスの終了コードを受け取ると、それによって起動した他のプロセスも終了するというdockerの性質によるものである。

`spring server` を別コンテナで起動して rails関連のコンテナでソケットファイルを共有することで、この問題を解決する

# やったこと
- docker-compose.ymlのRails環境を実行するコンテナの共通設定を切り出す
- springコンテナを追加
  - bin/spring server を実行
  - springのsocketファイル吐き出し先を/tmp/springに変更
    - /tmp/springをdocker volumeでapiコンテナと共有する
  - railsコマンドとrakeコマンドの実行先をspringコンテナに変更
  - 環境を立ち上げる際にspringのソケットファイルを初期化
