### PR TITLE
Docker環境のDBにローカルから接続できるようにする

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: password
     image: mysql:5.7
+    ports:
+      - '3306:3306'
     volumes:
       - mysql:/var/lib/mysql
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ x-custom:
 services:
   api:
     <<: *rails
-    command: bin/rails s puma
+    command: ["bin/rails", "s", "puma"]
     container_name: docker-sample_api
     ports:
       - '3000:3000'
@@ -29,7 +29,7 @@ services:
     container_name: docker-sample_spring
     command: bin/spring server
   db:
-    command: --sql_mode="NO_ENGINE_SUBSTITUTION"
+    command: ["--sql_mode=NO_ENGINE_SUBSTITUTION"]
     container_name: docker-sample_db
     environment:
       MYSQL_ROOT_PASSWORD: password


### PR DESCRIPTION
# 目的
Docker環境のDBにローカルから接続できるようにする

# やったこと
- ローカルの3306ポートをDocker環境のMysqlに割り当て
- docker-compose.ymlで指定するCMDをexec形式に変更 (リファクタリング)