### PR TITLE
キャッシュコンテナを利用

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ bin/docker {command}
 | init | docker環境を初期化する | bin/docker init |
 | rails | rails コマンドを実行する | bin/docker rails c |
 | rake | rake コマンドを実行する | bin/docker rake db:schema:load |
+| redis-cli | redis-cli コマンドを実行して指定したコンテナのデータを見る | bin/docker redis-cli cache |
 | rubocop | rubocop コマンドを実行する | bin/docker rubocop |
 | run | 任意のコンテナを立ち上げてコマンドを実行する | bin/docker run web bundle install |
 | stats | コンテナのリソース監視する  | bin/docker stats |

--- a/bin/docker
+++ b/bin/docker
@@ -19,6 +19,7 @@ Commands:
   init        Initialize docker images, network, and volumes
   rails       Run rails in spring container
   rake        Run rake in spring container
+  rails       Run redis-cli in spring container
   rubocop     Run rubocop in spring container
   run         Start choosed container and run command
   stats       Display a live stream of containers resource usage statistics
@@ -89,6 +90,10 @@ function rails() {
 
 function rake() {
   docker-compose exec spring bin/rake $@
+}
+
+function redis-cli() {
+  docker-compose exec spring redis-cli -h $1
 }
 
 function rubocop() {
@@ -205,6 +210,12 @@ case "${1}" in
   "rake")
     shift
     rake $@
+    exit 1
+  ;;
+
+  "redis-cli")
+    shift
+    redis-cli $@
     exit 1
   ;;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ x-custom:
     build: ./api
     depends_on:
       - db
+      - cache
     environment:
       DEVELOPMENT_DB_HOST: db
       DEVELOPMENT_DB_PASSWORD: password
@@ -41,6 +42,11 @@ services:
       - '3306:3306'
     volumes:
       - mysql:/var/lib/mysql
+  cache:
+    container_name: docker-sample_cache
+    image: redis:5.0.3-alpine
+    volumes:
+      - cache_store:/data
   mailhog:
     build: ./mailhog
     container_name: docker-sample_mailhog
@@ -61,3 +67,5 @@ volumes:
     name: docker-sample_db_mysql
   maildir:
     name: docker-sample_mailhog_maildir
+  cache_store:
+    name: docker-sample_cache_store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ x-custom:
       - db
       - cache
     environment:
+      CACHE_STORE_URL: redis://cache/0
       DEVELOPMENT_DB_HOST: db
       DEVELOPMENT_DB_PASSWORD: password
       DEVELOPMENT_SMTP_ADDRESS: mailhog


### PR DESCRIPTION
# 目的
Railsが利用するキャッシュの保存先としてredisを動かすコンテナを追加

# やったこと
- cacheコンテナを追加
  - redis 5.0.3
  - alpine(軽量コンテナ)を利用
  - キャッシュの内容はdocker volumeに保存
- railsが利用するキャッシュ保存先のURLを環境変数で指定
- bin/docker redis-cli でredisの中身を見れるようにする
