### PR TITLE
ngrokを使ってアクセスした場合のBasic認証を設定できるようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 api
 
 mailhog/outgoing_smtp.json
+
+.env

--- a/README.md
+++ b/README.md
@@ -102,3 +102,23 @@ mailhogには受信したメールを再転送する仕組みがある。
 ### 参考
 [https://github.com/mailhog/MailHog](https://github.com/mailhog/MailHog)
 
+
+## ngrok
+ngrokを利用することでlocalhostを外部に公開できるようになる
+
+### ngrokの使い方
+ngrokの使い方はこのあたりを読むこと
+https://qiita.com/kitaro729/items/44214f9f81d3ebda58bd
+
+### BasicAuth
+`*.ngrok.io` でアクセスが来た場合はBasicAuthが必要な設定にしてある
+
+BasicAuthのユーザー名とパスワードは.envで以下の環境変数で設定すること
+
+```
+NGROK_BASIC_USER={好きなユーザー名}
+NGROK_BASIC_PASS={好きなパスワード}
+```
+
+### 参考
+[ngrok](https://ngrok.com/)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ x-custom:
       DEVELOPMENT_DB_PASSWORD: password
       DEVELOPMENT_SMTP_ADDRESS: mailhog
       DEVELOPMENT_SMTP_PORT: 1025
+      NGROK_BASIC_PASS: "${NGROK_BASIC_PASS}"
+      NGROK_BASIC_USER: "${NGROK_BASIC_USER}"
       SITE_HOST: localhost
       SPRING_TMP_PATH: /api/tmp/spring
       TEST_DB_HOST: db


### PR DESCRIPTION
# 目的
以下のPRでngrokを使ってアクセスした場合のBasic認証を設定できるようにした
https://github.com/snowfield702/rails-sample/pull/16

Basic認証のユーザー名とパスワードは環境変数を利用するため .envで設定できるようにした

# やったこと
- README.md を修正
- .envをgitignoreに追加
- 環境変数を追加
  - NGROK_BASIC_PASS
  - NGROK_BASIC_USER


