### PR TITLE
環境初期化時にgit cloneを最初に実行する

### DIFF
--- a/bin/docker
+++ b/bin/docker
@@ -70,16 +70,17 @@ function execute() {
 }
 
 function init() {
-  if [ -e tmp/docker-init.lock ]; then
-    destroy
-  fi
   echo -e $'\n\e[32mInitialize docker images, network, and volumes\e[m'
+
   if [ ! -e api ]; then
      git clone git@github.com:snowfield702/rails-sample.git api
   fi
+
   if [ ! -e mailhog/outgoing_smtp.json ]; then
      cp mailhog/outgoing_smtp.json.sample mailhog/outgoing_smtp.json
   fi
+
+  destroy
   bundle_install
   init_db
   touch tmp/docker-init.lock


### PR DESCRIPTION
# 目的
環境初期化時にgit cloneを最初に実行する
git cloneされていないとbin/docker destroyが正しく実行されないため、destroyよりgit cloneを先に実行する必要があった

# やったこと
- bin/dockerを修正