### PR TITLE
frontコンテナに対する初期化処理を追加

### DIFF
--- a/bin/docker
+++ b/bin/docker
@@ -79,7 +79,7 @@ function init() {
   init_files
 
   destroy
-  bundle_install
+  install_packages
   init_db
   touch tmp/docker-init.lock
 }
@@ -155,7 +155,7 @@ function top() {
 function up() {
   init_if_need
   echo -e $'\n\e[32mStart containers as foreground\e[m'
-  bundle_install
+  install_packages
   rm_pids
   docker-compose up
 }
@@ -184,8 +184,9 @@ function init_db() {
   docker-compose run --rm api bundle exec rails db:create db:migrate db:test:prepare
 }
 
-function bundle_install() {
+function install_packages() {
   docker-compose run --rm api bundle install -j4 --system --clean
+  docker-compose run --rm front yarn install
 }
 
 shift `expr $OPTIND - 1`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,10 @@ services:
       - mysql:/var/lib/mysql
   front:
     build: ./front
+    command: ["npm", "start"]
     container_name: docker-sample_front
+    ports:
+      - '3001:3000'
     stdin_open: true
     tty: true
     volumes:


### PR DESCRIPTION
# 目的
frontコンテナに対する初期化処理を追加する

# やったこと
- 環境構築時にyarn installを実行する
- 環境起動時にfrontコンテナでnpm startを実行
- ローカル環境のport3001をfrontコンテナのport3000に紐付ける