### PR TITLE
yarnの利用を廃止する

### DIFF
--- a/bin/docker
+++ b/bin/docker
@@ -30,7 +30,6 @@ Commands:
   stop        Stop containers
   top         Display the running processes
   up          Start containers as foreground
-  yarn        Run yarn in front container
 EOF
 }
 
@@ -160,10 +159,6 @@ function up() {
   docker-compose up
 }
 
-function yarn() {
-  docker-compose exec front yarn $@
-}
-
 function rm_pids() {
   if [ -e api/tmp/spring ]; then
      rm -rf api/tmp/spring
@@ -186,7 +181,7 @@ function init_db() {
 
 function install_packages() {
   docker-compose run --rm api bundle install -j4 --system --clean
-  docker-compose run --rm front yarn install
+  docker-compose run --rm front npm install
 }
 
 shift `expr $OPTIND - 1`
@@ -313,12 +308,6 @@ case "${1}" in
 
   "up")
     up
-    exit 1
-  ;;
-
-  "yarn")
-    shift
-    yarn $@
     exit 1
   ;;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - mysql:/var/lib/mysql
   front:
     build: ./front
-    command: ["yarn", "start"]
+    command: ["npm", "start"]
     container_name: docker-sample_front
     ports:
       - '3001:3000'


### PR DESCRIPTION
# 目的
npmの改善によってyarnを利用するメリットが少なくなったため、yarnの運用を廃止する
- パッケージのインストール速度の差が少なくなった
- package-lock.jsonによって依存パッケージもバージョン管理されるようになった

# やったこと
- binstubsとdocker-compose.ymlで利用するコマンドをyarnからnpmに変更